### PR TITLE
feat: change deprecated kSecAttrKeyTypeEC to recommended

### DIFF
--- a/Sources/Keychain/secretkey/KeyEncrypting.swift
+++ b/Sources/Keychain/secretkey/KeyEncrypting.swift
@@ -104,7 +104,7 @@ public final class KeyEncrypting: KeyEncryptable {
             nil
         )
         var result: [String: Any] = [
-            kSecAttrKeyType as String: kSecAttrKeyTypeEC,
+            kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
             kSecAttrKeySizeInBits as String: 256,
             kSecAttrAccessGroup as String: Constants.accessGroup,
             kSecPrivateKeyAttrs as String: [


### PR DESCRIPTION
## Description
We were using a deprecated elliptic curve algorithm key type. Apple's recommendation is to use kSecAttrKeyTypeECSECPrimeRandom instead.

## Reference
https://developer.apple.com/documentation/security/ksecattrkeytypeec